### PR TITLE
Update BancoDoNordeste.php

### DIFF
--- a/src/OpenBoleto/Banco/BancoDoNordeste.php
+++ b/src/OpenBoleto/Banco/BancoDoNordeste.php
@@ -62,7 +62,7 @@ class BancoDoNordeste extends BoletoAbstract
      * Define as carteiras disponíveis para este banco
      * @var array
      */
-    protected $carteiras = array('47','45','46','50','45','46','04','48','97','51','49','52','58','95','63','53','54','55','57','59','61');
+    protected $carteiras = array('21','47','45','46','50','45','46','04','48','97','51','49','52','58','95','63','53','54','55','57','59','61');
 
     /**
      * Gera o Nosso Número com o dígito verificador
@@ -72,7 +72,7 @@ class BancoDoNordeste extends BoletoAbstract
     protected function gerarNossoNumero()
     {
         $numero = static::zeroFill($this->sequencial, 7);
-        $resto = static::modulo11($numero, 8)['resto'];
+        $resto = static::modulo11($numero, 7)['resto'];  // correção para o DV do Nosso Número
         $dv = 0;
 
         if ($resto > 1) {


### PR DESCRIPTION
Inclusão da carteira 21 no array de carteiras.
Correção na função gerarNossoNumero(), no cálculo do DV do Nosso Número. O Módulo 11 estava sendo calculado levando em conta todos os 08 (oito) dígitos do Nosso Número, no entanto, para o cálculo correto, devem ser levados em conta apenas os 07 (sete) primeiros dígitos como consta no manual do banco, o oitavo dígito que acompanhará o Nosso Número refere-se ao DV do Nosso Número. Da forma como estava, algumas vezes o DV da Linha Digitável saia correto e em outros casos não. Espero ter ajudado, obrigado.